### PR TITLE
Fix euler2rot code mistake

### DIFF
--- a/data_util/face_tracking/util.py
+++ b/data_util/face_tracking/util.py
@@ -33,8 +33,8 @@ def euler2rot(euler_angle):
         torch.cat((phi.sin(), zero, phi.cos()), 1),
     ), 2)
     rot_z = torch.cat((
-        torch.cat((psi.cos(), -psi.sin(), zero), 1),
-        torch.cat((psi.sin(), psi.cos(), zero), 1),
+        torch.cat((psi.cos(), psi.sin(), zero), 1),
+        torch.cat((-psi.sin(), psi.cos(), zero), 1),
         torch.cat((zero, zero, one), 1)
     ), 2)
     return torch.bmm(rot_x, torch.bmm(rot_y, rot_z))


### PR DESCRIPTION
There is a mistake in the current `euler2rot` code, the rotation matrix around the z-axis is not correctly composed. With this fix, `euler2rot` now behaves the same as `euler_angles_to_matrix(eulers, 'XYZ')` from `pytorch3D.transforms`.